### PR TITLE
Mass Deleter: Show mass unlike menu

### DIFF
--- a/Extensions/mass_deleter.css
+++ b/Extensions/mass_deleter.css
@@ -7,3 +7,14 @@
 	opacity: 0.42;
 
 }
+
+#xkit-mass-deleter-ul > .no_push {
+	height: 36px;
+}
+
+#xkit-mass-deleter-ul .hide_overflow {
+	color: rgba(255, 255, 255, 0.5) !important;
+	font-weight: bold;
+	padding-left: 10px;
+	padding-top: 8px;
+}

--- a/Extensions/mass_deleter.js
+++ b/Extensions/mass_deleter.js
@@ -1,5 +1,5 @@
 //* TITLE Mass Deleter **//
-//* VERSION 0.1 REV G **//
+//* VERSION 0.1.1 **//
 //* DESCRIPTION Mass unlike likes / delete drafts **//
 //* DETAILS Used to mass unlike posts or delete drafts. Please use with caution, especially Mass Unlike part is extremely experimental. **//
 //* DEVELOPER STUDIOXENIX **//

--- a/Extensions/xkit_patches.js
+++ b/Extensions/xkit_patches.js
@@ -1,5 +1,5 @@
 //* TITLE XKit Patches **//
-//* VERSION 3.0.6 **//
+//* VERSION 3.0.7 **//
 //* DESCRIPTION Patches framework **//
 //* DEVELOPER STUDIOXENIX **//
 
@@ -1909,7 +1909,8 @@ XKit.tools.get_blogs = function() {
 					drafts: false,
 					followers: false,
 					endless: false,
-					dashboard: false
+					dashboard: false,
+					likes: false
 				};
 
 				if ($("body").hasClass("dashboard_messages_inbox") === true || $("body").hasClass("dashboard_messages_submissions") === true) {
@@ -1984,6 +1985,11 @@ XKit.tools.get_blogs = function() {
 
 				if (document.location.href.indexOf("tumblr.com/search/") !== -1) {
 					m_return.search = true;
+				}
+
+				if ($("body").hasClass("dashboard_posts_likes") == true ||
+						document.location.href.indexOf("tumblr.com/likes/") !== -1) {
+					m_return.likes = true;
 				}
 
 				m_return.dashboard = $("body").hasClass("is_dashboard") === true;


### PR DESCRIPTION
I have not actually tested whether the functionality still works, but at least the menu shows up now.