### PR TITLE
Post-limit-checker actually works now

### DIFF
--- a/Extensions/post_limit_checker.js
+++ b/Extensions/post_limit_checker.js
@@ -179,7 +179,7 @@ XKit.extensions.post_limit_checker = new Object({
 					for (var i=0;i<data.response.posts.length;i++) {
 
 						// I would check the date here but I'm a lazy man.
-						posts.push(data.response.posts[i]);
+						posts[index].push(data.response.posts[i]);
 
 					}
 

--- a/Extensions/post_limit_checker.js
+++ b/Extensions/post_limit_checker.js
@@ -1,5 +1,5 @@
 //* TITLE Post Limit Checker **//
-//* VERSION 0.2.0 **//
+//* VERSION 0.2.1 **//
 //* DESCRIPTION Are you close to the limit? **//
 //* DETAILS Shows you how many posts you can reblog today. **//
 //* DEVELOPER STUDIOXENIX **//
@@ -183,7 +183,7 @@ XKit.extensions.post_limit_checker = new Object({
 
 					}
 
-					XKit.progress.value("post-limit-checker-progress", (posts.length / 2.5) - 10);
+					XKit.progress.value("post-limit-checker-progress", (posts[index].length / 2.5) - 10);
 
 					if (posts[index].length >= 250 || data.response.posts.length === 0) {
 						if (index < blogs.length - 1) {


### PR DESCRIPTION
I forgot to change ```posts``` to ```posts[index]``` in the progress bar and when pushing posts from the GET response when first updating post-limit-checker to look at all blogs, but everything works now.