### PR TITLE
Fix one click postage

### DIFF
--- a/Extensions/one_click_postage.js
+++ b/Extensions/one_click_postage.js
@@ -1447,18 +1447,6 @@ XKit.extensions.one_click_postage = new Object({
 			m_object["post[tags]"] = "";
 		}
 
-
-
-		// Call Auto Tagger for tags if enabled
-		var additional_tags = this.get_auto_tagger_tags(data.post, state, false);
-		if (additional_tags !== "") {
-			if (m_object["post[tags]"] === "") {
-				m_object["post[tags]"] = additional_tags;
-			} else {
-				m_object["post[tags]"] = m_object["post[tags]"] + "," + additional_tags;
-			}
-		}
-
 		m_object["post[publish_on]"] ="";
 		if (state === 0) {
 			m_object["post[state]"] = "";


### PR DESCRIPTION
at this point in the game, we can remove autotagger, because autotagger has already inserted its tags into the tag editor